### PR TITLE
Workflow to automate releasing the Helm charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1
+        with:
+          charts_dir: ocp-helm-charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# HOWTO: https://pre-commit.com/#usage
+# pip3 install pre-commit
+# pre-commit install -t pre-commit -t pre-push
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.17
+    hooks:
+      - id: helmlint
+  - repo: https://github.com/packit/pre-commit-hooks
+    rev: 8db5a24e01b9f54aaa7a800f33c4b9aa619af1b9
+    hooks:
+      - id: check-rebase
+        args:
+          - https://github.com/packit/udp.git
+        stages: [manual, push]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # udp
 
-[Unified Openshift deployment Project](https://docs.google.com/presentation/d/1MlLuuawzxJg6U15zbPby6JAtNNEWZAhfGEWNcpYSWeo) for the [Packit Validation Service](https://github.com/packit/deployment/tree/main/cron-jobs/packit-service-validation).
+[Unified Openshift deployment Project](https://docs.google.com/presentation/d/1MlLuuawzxJg6U15zbPby6JAtNNEWZAhfGEWNcpYSWeo)
+for the [Packit Service Validation](https://github.com/packit/deployment/tree/main/cron-jobs/packit-service-validation).
 
-To deploy the *Packit Validation Service* through *Helm* into *cyborg* follow this steps:
+To deploy the *Packit Service Validation* through *Helm* follow this steps:
 
 ### Setup deployment
 
-Helm uses an **image** created through a GitHub action and pushed to Quay.io, the **tag** for this image is the first *7 digit for the commit SHA* of the packit/deployment repo.
+Helm uses an **image** created through a GitHub action and pushed to Quay.io,
+the **tag** for this image is the first *7 digit for the commit SHA* of the packit/deployment repo.
 
 To use a new image update the referenced tag [here](https://github.com/packit/udp/blob/main/ocp-deployments/packit-service-validation-prod.yaml#L18).
 
@@ -20,12 +22,31 @@ export PACKIT_SENTRY=$( echo -n 'token from bitwarden' | base64 )
 export PACKIT_GITHUB_TOKEN=$( echo -n 'token from bitwarden' | base64 )
 ```
 
-### Install Service
+### Install Helm Chart
+
+#### From this repo
 ```
 helm upgrade --install --cleanup-on-fail packit-service-validation ocp-helm-charts/packit-service-validation/ --set secrets.sentry=${PACKIT_SENTRY} --set secrets.github=${PACKIT_GITHUB_TOKEN} --values ocp-deployments/packit-service-validation-prod.yaml
 ```
 
-### Uninstall Service
+#### From chart repository
+```
+helm repo add packit https://helm.packit.dev
+helm repo update
+helm upgrade --install --cleanup-on-fail packit-service-validation packit/packit-service-validation --set secrets.sentry=${PACKIT_SENTRY} --set secrets.github=${PACKIT_GITHUB_TOKEN} --values ocp-deployments/packit-service-validation-prod.yaml
+```
+
+### Uninstall Helm Chart
 ```
 helm uninstall packit-service-validation
 ```
+
+### Releases
+There's a [release workflow](.github/workflows/release.yml) to automate releasing the Helm charts.
+It uses [Helm Chart Releaser Action](https://github.com/marketplace/actions/helm-chart-releaser)
+which turns this project into a self-hosted Helm chart repository.
+It does this – during every push to `main` – by checking each chart in the project,
+and whenever there's a new chart version, creates a corresponding GitHub release
+named for the chart version, adds Helm chart artifacts to the release,
+and creates or updates an `index.yaml` file with metadata about those releases,
+which is then hosted on GitHub Pages at https://helm.packit.dev.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ export PACKIT_GITHUB_TOKEN=$( echo -n 'token from bitwarden' | base64 )
 
 ### Install Service
 ```
-helm upgrade --install --cleanup-on-fail packit-service-validation ocp-helm-charts/packit-service-validation/ --set oc_namespace=cyborg --set secrets.sentry=${PACKIT_SENTRY} --set secrets.github=${PACKIT_GITHUB_TOKEN} --values ocp-deployments/packit-service-validation-prod.yaml
+helm upgrade --install --cleanup-on-fail packit-service-validation ocp-helm-charts/packit-service-validation/ --set secrets.sentry=${PACKIT_SENTRY} --set secrets.github=${PACKIT_GITHUB_TOKEN} --values ocp-deployments/packit-service-validation-prod.yaml
 ```
 
 ### Uninstall Service

--- a/ocp-deployments/packit-service-validation-prod.yaml
+++ b/ocp-deployments/packit-service-validation-prod.yaml
@@ -32,12 +32,12 @@ env_variables:
   deployment:
     value: production
 
-# Cron job parameters 
+# Cron job parameters
 cron:
   # Schedule
   # runs every day at 4 a.m.
   schedule: "0 4 * * *"
-  concurrencyPolicy: "Allow" 
+  concurrencyPolicy: "Allow"
   startingDeadlineSeconds: 14400
   suspend: false
   successfulJobsHistoryLimit: 5

--- a/ocp-helm-charts/packit-service-validation/Chart.yaml
+++ b/ocp-helm-charts/packit-service-validation/Chart.yaml
@@ -13,4 +13,3 @@ keywords:
 maintainers:
   - name : Serhii Turivnyi
     email: sturivny@redhat.com
-

--- a/ocp-helm-charts/packit-service-validation/Chart.yaml
+++ b/ocp-helm-charts/packit-service-validation/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion  : v1
+apiVersion  : v2
 name        : packit-service-validation
 description : Helm chart for deploying packit-service-validation app
 type        : application

--- a/ocp-helm-charts/packit-service-validation/values.yaml
+++ b/ocp-helm-charts/packit-service-validation/values.yaml
@@ -32,11 +32,11 @@ env_variables:
   deployment:
     value: production
 
-# Cron job parameters 
+# Cron job parameters
 cron:
   # Schedule
   schedule:
-  concurrencyPolicy: "Allow" 
+  concurrencyPolicy: "Allow"
   startingDeadlineSeconds: ~
   suspend: false
   successfulJobsHistoryLimit: 5


### PR DESCRIPTION
It uses [Helm Chart Releaser Action](https://github.com/marketplace/actions/helm-chart-releaser) which turns this project into a self-hosted Helm chart repository. It does this – during every push to `main` – by checking each chart in the project, and whenever there's a new chart version, creates a corresponding GitHub release named for the chart version, adds Helm chart artifacts to the release, and creates or updates an `index.yaml` file with metadata about those releases, which is then hosted on GitHub Pages at https://helm.packit.dev (once this is merged).

Fixes #6 